### PR TITLE
feat: add logout() method to Ergani facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `logout()` method to the `Ergani` facade for revoking refresh tokens server-side
+
 ## [2.0.1] - 2026-06-12
 
 > [!NOTE]

--- a/docs/api/ergani.md
+++ b/docs/api/ergani.md
@@ -75,6 +75,38 @@ echo $token->accessTokenExpiresAt->format('Y-m-d H:i:s');
 
 ---
 
+### logout()
+
+Invalidate the session by deleting the refresh token from the API server.
+
+```php
+public function logout(string $refreshToken): bool
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `$refreshToken` | string | - | The refresh token to revoke |
+
+**Returns:** `bool` - `true` if the refresh token was revoked
+
+**Throws:** `ErganiException`
+
+**Example:**
+
+```php
+$ergani = new Ergani($accessToken);
+
+$ergani->logout($refreshToken);
+```
+
+::: tip
+After logging out, the refresh token can no longer be used to obtain new access tokens. Call `authenticate()` again to start a new session.
+:::
+
+---
+
 ### getServices()
 
 Get list of available services for the authenticated user.

--- a/docs/guide/token-management.md
+++ b/docs/guide/token-management.md
@@ -114,6 +114,23 @@ $response = $workCard->handle($card);
 
 This approach requires you to handle token refresh and expiration manually.
 
+## Logging Out
+
+To invalidate a session server-side, revoke the refresh token through the `Ergani` facade:
+
+```php
+use OxygenSuite\OxygenErgani\Ergani;
+
+$ergani = new Ergani($accessToken);
+$ergani->logout($refreshToken);
+```
+
+After logout, the refresh token can no longer be used to obtain new access tokens. A new session requires re-authentication with username and password.
+
+::: warning
+If you use a token manager, it does not know the token was revoked. The stored refresh token will fail on next use, triggering automatic re-authentication.
+:::
+
 ## Laravel Integration
 
 Set up the token manager in a service provider:

--- a/src/Ergani.php
+++ b/src/Ergani.php
@@ -17,6 +17,7 @@ use OxygenSuite\OxygenErgani\Ergani\Concerns\SendsTerminationDocuments;
 use OxygenSuite\OxygenErgani\Ergani\Concerns\SendsWorkTimeDocuments;
 use OxygenSuite\OxygenErgani\Exceptions\ErganiException;
 use OxygenSuite\OxygenErgani\Http\Auth\AuthenticationLogin;
+use OxygenSuite\OxygenErgani\Http\Auth\AuthenticationLogout;
 use OxygenSuite\OxygenErgani\Http\ClientConfig;
 use OxygenSuite\OxygenErgani\Http\Documents\WorkCard\WorkCard;
 use OxygenSuite\OxygenErgani\Http\Services\AcceptanceStatus;
@@ -95,6 +96,20 @@ class Ergani
         $auth = new AuthenticationLogin($this->environment, $this->config);
 
         return $auth->handle($username, $password, $userType);
+    }
+
+    /**
+     * Invalidate the session by deleting the refresh token from the API server.
+     *
+     * @param string $refreshToken The refresh token to revoke
+     *
+     * @throws ErganiException
+     */
+    public function logout(string $refreshToken): bool
+    {
+        $auth = new AuthenticationLogout($this->accessToken, $this->environment, $this->config);
+
+        return $auth->handle($refreshToken);
     }
 
     /**

--- a/tests/ErganiTest.php
+++ b/tests/ErganiTest.php
@@ -409,6 +409,14 @@ class ErganiTest extends TestCase
         $this->assertIsArray($schema);
     }
 
+    public function test_logout(): void
+    {
+        $config = (new ClientConfig())->setHandler($this->mockResponse(200, 'empty.json'));
+        $ergani = new Ergani('test-access-token', config: $config);
+
+        $this->assertTrue($ergani->logout('test-refresh-token'));
+    }
+
     public function test_cancel_document(): void
     {
         $config = (new ClientConfig())->setHandler(new MockHandler([


### PR DESCRIPTION
## Summary

- Expose the previously-orphaned `AuthenticationLogout` HTTP client through the `Ergani` facade via a new `logout(string $refreshToken): bool` method, so consumers can revoke refresh tokens server-side without instantiating internal classes.
- Document the method in `docs/api/ergani.md` (Authentication & Services) and add a "Logging Out" section to `docs/guide/token-management.md`, including a note that token managers will simply re-authenticate after revocation.
- Add a changelog entry under `[Unreleased]`.

## Test plan

- [x] New `test_logout` in `tests/ErganiTest.php` (mocked HTTP, follows existing facade test pattern)
- [x] Full suite passes: 826 tests, 3096 assertions
- [x] PHPStan level 7: no errors
- [x] Pint: passes