### PR TITLE
feat: add Ergani::make() static constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `Ergani::make()` static constructor for fluent one-liners (e.g. `Ergani::make()->sendHiringNew($declaration)`)
 - Generate LLM-friendly documentation (`llms.txt`, `llms-full.txt`, per-page Markdown) and a sitemap for the docs site
 - Show last-updated dates and code group icons on docs pages; use clean URLs
 

--- a/docs/api/ergani.md
+++ b/docs/api/ergani.md
@@ -14,7 +14,8 @@ class Ergani
         ?Environment $environment = Environment::TEST,
         ?ClientConfig $config = null,
         ?CacheInterface $cache = null,
-        string $cachePrefix = '',
+        ?string $cachePrefix = null,
+        int $cacheTtl = 2_592_000,
     );
 }
 ```
@@ -29,6 +30,34 @@ class Ergani
 | `$cache` | CacheInterface\|null | `null` | PSR-16 cache for service responses |
 | `$cachePrefix` | string\|null | `null` | Cache key prefix. Null = auto-derive from TokenManager credentials. |
 | `$cacheTtl` | int | `2592000` | Cache TTL in seconds (default: 30 days) |
+
+### make()
+
+Static constructor for fluent one-liners. Accepts the same parameters as the constructor and returns a new instance.
+
+```php
+public static function make(
+    ?string $accessToken = null,
+    ?Environment $environment = Environment::TEST,
+    ?ClientConfig $config = null,
+    ?CacheInterface $cache = null,
+    ?string $cachePrefix = null,
+    int $cacheTtl = 2_592_000,
+): static
+```
+
+**Example:**
+
+```php
+use OxygenSuite\OxygenErgani\Ergani;
+use OxygenSuite\OxygenErgani\Enums\Environment;
+
+// Equivalent to (new Ergani())->sendHiringNew($declaration)
+$responses = Ergani::make()->sendHiringNew($declaration);
+
+// With configuration
+$employer = Ergani::make($accessToken, Environment::PRODUCTION)->getEmployerInfo();
+```
 
 ---
 

--- a/src/Ergani.php
+++ b/src/Ergani.php
@@ -41,6 +41,7 @@ use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 use ReflectionClass;
 
+/** @phpstan-consistent-constructor */
 class Ergani
 {
     use ManagesDocuments;
@@ -86,6 +87,29 @@ class Ergani
         $this->cache = $cache;
         $this->cachePrefix = $cachePrefix ?? $this->deriveCachePrefix();
         $this->cacheTtl = $cacheTtl;
+    }
+
+    /**
+     * Create a new instance fluently.
+     *
+     * Accepts the same arguments as the constructor.
+     *
+     * @param ?string $accessToken Bearer token (null when using TokenManager)
+     * @param ?Environment $environment API environment
+     * @param ?ClientConfig $config Custom HTTP client configuration
+     * @param ?CacheInterface $cache PSR-16 cache for service responses
+     * @param ?string $cachePrefix Cache key prefix. Null = auto-derive from TokenManager credentials. Empty string = no prefix.
+     * @param int $cacheTtl Cache TTL in seconds (default: 30 days)
+     */
+    public static function make(
+        ?string $accessToken = null,
+        ?Environment $environment = Environment::TEST,
+        ?ClientConfig $config = null,
+        ?CacheInterface $cache = null,
+        ?string $cachePrefix = null,
+        int $cacheTtl = self::DEFAULT_CACHE_TTL,
+    ): static {
+        return new static($accessToken, $environment, $config, $cache, $cachePrefix, $cacheTtl);
     }
 
     /**

--- a/tests/ErganiTest.php
+++ b/tests/ErganiTest.php
@@ -417,6 +417,23 @@ class ErganiTest extends TestCase
         $this->assertTrue($ergani->logout('test-refresh-token'));
     }
 
+    public function test_make_returns_new_instance(): void
+    {
+        $ergani = Ergani::make();
+
+        $this->assertInstanceOf(Ergani::class, $ergani);
+        $this->assertNotSame($ergani, Ergani::make());
+    }
+
+    public function test_make_forwards_constructor_arguments(): void
+    {
+        $config = (new ClientConfig())->setHandler($this->mockResponse(200, 'ex-base-01.json'));
+
+        $employer = Ergani::make('test-access-token', config: $config)->getEmployerInfo();
+
+        $this->assertSame('ERGANI A.E', $employer->name);
+    }
+
     public function test_cancel_document(): void
     {
         $config = (new ClientConfig())->setHandler(new MockHandler([


### PR DESCRIPTION
## Summary

Adds a `make()` static constructor to the `Ergani` facade for fluent one-liners:

```php
$responses = Ergani::make()->sendHiringNew($declaration);
```

It mirrors the constructor signature exactly and returns `static`, keeping IDE autocompletion and PHPStan happy (with `@phpstan-consistent-constructor` for safe `new static()`).

Includes tests, docs (`docs/api/ergani.md`, plus a fix for its stale class definition), and a changelog entry.

## Verification

- 828 tests pass, PHPStan level 7 clean, Pint clean