### PR TITLE
chore: add Context7 config and docs refresh workflow

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -1,0 +1,19 @@
+name: Refresh Context7 Docs
+
+on:
+  push:
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Context7 Refresh
+        run: |
+          curl -s -X POST https://context7.com/api/v1/refresh \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.CONTEXT7_API_KEY }}" \
+            -d '{"libraryName": "/${{ github.repository }}"}'

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://context7.com/schema/context7.json",
+    "projectTitle": "Oxygen Ergani",
+    "description": "PHP package for Greece's ERGANI employment system API: work cards, hiring (E3), terminations (E5/E6/E7), employment modifications (MA), work time declarations, and query services",
+    "folders": ["docs"],
+    "excludeFolders": ["vendor", "tests", "storage", "node_modules", "docs/.vitepress"],
+    "excludeFiles": ["CHANGELOG.md"],
+    "rules": [
+        "Use the Ergani facade for common operations instead of instantiating document classes directly",
+        "Set up a TokenManager via Token::setCurrentTokenManager() instead of passing access tokens manually",
+        "Date setters accept both DateTime objects and DD/MM/YYYY strings",
+        "Decimal fields are formatted automatically to Greek format (1.234,56) via the casts system; pass plain floats to setters"
+    ]
+}


### PR DESCRIPTION
Adds `context7.json` (fixes the wrong auto-generated title/description on Context7 and scopes parsing to `docs/`) and a workflow that triggers Context7 re-indexing on every push to master.

Verified the library is indexed at https://context7.com/oxygensuite/oxygen-ergani; the workflow requires a `CONTEXT7_API_KEY` repository secret.