### PR TITLE
fix: fail Context7 refresh workflow on API errors

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Trigger Context7 Refresh
         run: |
-          curl -s -X POST https://context7.com/api/v1/refresh \
+          curl -s --fail-with-body -X POST https://context7.com/api/v1/refresh \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.CONTEXT7_API_KEY }}" \
             -d '{"libraryName": "/${{ github.repository }}"}'


### PR DESCRIPTION
Use `--fail-with-body` so the refresh step turns red on API errors (the invalid-key failure passed silently).

Verified by inspecting the previous run log where the error response was hidden behind a green check.