### PR TITLE
chore: add Context7 ownership claim fields

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
     "$schema": "https://context7.com/schema/context7.json",
+    "url": "https://context7.com/oxygensuite/oxygen-ergani",
+    "public_key": "pk_ZG7aPNylxrCD0WeyQQEyO",
     "projectTitle": "Oxygen Ergani",
     "description": "PHP package for Greece's ERGANI employment system API: work cards, hiring (E3), terminations (E5/E6/E7), employment modifications (MA), work time declarations, and query services",
     "folders": ["docs"],


### PR DESCRIPTION
Add the `url` and `public_key` fields Context7 verifies when claiming library ownership (the public key is meant to be public).

Verified the claiming process against Context7 docs: the file must be in the repo root, then "Claim Library" is clicked on the library admin page.